### PR TITLE
Dictionary uses stable order. This fixes unit tests.

### DIFF
--- a/src/main/java/org/simpleframework/xml/util/Dictionary.java
+++ b/src/main/java/org/simpleframework/xml/util/Dictionary.java
@@ -19,8 +19,8 @@
 package org.simpleframework.xml.util;
 
 import java.util.AbstractSet;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 
 /**
  * The <code>Dictionary</code> object represents a mapped set of entry
@@ -134,7 +134,7 @@ public class Dictionary<T extends Entry> extends AbstractSet<T> {
     *
     * @see org.simpleframework.xml.util.Entry
     */
-   private static class Table<T> extends HashMap<String, T> {
+   private static class Table<T> extends LinkedHashMap<String, T> {
       
       /**
        * Constructor for the <code>Table</code> object. This will


### PR DESCRIPTION
ConversionTest and RegistryStrategyTest had failures, because they rely on the insertion order in the Dictionary.
