### PR TITLE
Support serializing mixed content.

### DIFF
--- a/src/main/java/org/simpleframework/xml/stream/Formatter.java
+++ b/src/main/java/org/simpleframework/xml/stream/Formatter.java
@@ -159,17 +159,20 @@ class Formatter {
     * front of the tag, this is done for all but the first start tag.
     * 
     * @param name this is the name of the start tag to be written
+    * @param indent set to <code>false</code> if indentation should be omitted.
     *
     * @throws Exception thrown if there is an I/O exception
     */ 
-   public void writeStart(String name, String prefix) throws Exception{
+   public void writeStart(String name, String prefix, boolean indent) throws Exception{
       String text = indenter.push();
 
       if(last == Tag.START) {
          append('>');    
       }        
       flush();
-      append(text);
+      if (indent) {
+    	 append(text);
+      }
       append('<');
       
       if(!isEmpty(prefix)) {
@@ -270,17 +273,18 @@ class Formatter {
     * some text was written then a full end tag is written.
     *
     * @param name this is the name of the element to be closed
+    * @param indent set to <code>false</code> if indentation should be omitted.
     *
     * @throws Exception thrown if there is an I/O exception
     */ 
-   public void writeEnd(String name, String prefix) throws Exception {
+   public void writeEnd(String name, String prefix, boolean indent) throws Exception {
       String text = indenter.pop();
 
       if(last == Tag.START) {
          write('/');
          write('>');
       } else {                       
-         if(last != Tag.TEXT) {
+         if(last != Tag.TEXT && indent) {
             write(text);   
          }                        
          if(last != Tag.START) {

--- a/src/main/java/org/simpleframework/xml/stream/IndentationMode.java
+++ b/src/main/java/org/simpleframework/xml/stream/IndentationMode.java
@@ -1,0 +1,6 @@
+package org.simpleframework.xml.stream;
+
+public enum IndentationMode {
+	ENABLED,
+	DISABLED
+}

--- a/src/main/java/org/simpleframework/xml/stream/NodeWriter.java
+++ b/src/main/java/org/simpleframework/xml/stream/NodeWriter.java
@@ -231,9 +231,6 @@ class NodeWriter {
    private OutputNode writeStart(OutputNode parent, String name) throws Exception {
       OutputNode node = new OutputElement(parent, this, name);
 
-      if(name == null) {
-         throw new NodeException("Can not have a null name");
-      }          
       return stack.push(node);
    }
   

--- a/src/main/java/org/simpleframework/xml/stream/NodeWriter.java
+++ b/src/main/java/org/simpleframework/xml/stream/NodeWriter.java
@@ -276,8 +276,12 @@ class NodeWriter {
       String prefix = node.getPrefix(verbose);
       String name = node.getName();
       
+      // Don't indent if it is disabled on the parent.
+	  boolean indent = node.getParent() == null || node.getParent()
+	     .getIndentationMode() == IndentationMode.ENABLED;
+      
       if(name != null) {
-         writer.writeStart(name, prefix);
+         writer.writeStart(name, prefix, indent);
       }
    }
  
@@ -326,7 +330,7 @@ class NodeWriter {
          writeValue(node);
       }
       if(name != null) {
-         writer.writeEnd(name, prefix);
+         writer.writeEnd(name, prefix, node.getIndentationMode() == IndentationMode.ENABLED);
          writer.flush();
       }
    }

--- a/src/main/java/org/simpleframework/xml/stream/OutputAttribute.java
+++ b/src/main/java/org/simpleframework/xml/stream/OutputAttribute.java
@@ -350,4 +350,11 @@ class OutputAttribute implements OutputNode {
    public String toString() {
        return String.format("attribute %s='%s'", name, value);
    }
+   
+   public IndentationMode getIndentationMode() {
+      return null;
+   }
+   
+   public void setIndentationMode(IndentationMode mode) {
+   }
 }

--- a/src/main/java/org/simpleframework/xml/stream/OutputDocument.java
+++ b/src/main/java/org/simpleframework/xml/stream/OutputDocument.java
@@ -361,4 +361,11 @@ class OutputDocument implements OutputNode {
    public boolean isCommitted() {
       return stack.isEmpty();
    }
+   
+   public IndentationMode getIndentationMode() {
+      return null;
+   }
+   
+   public void setIndentationMode(IndentationMode mode) {
+   }
 }

--- a/src/main/java/org/simpleframework/xml/stream/OutputElement.java
+++ b/src/main/java/org/simpleframework/xml/stream/OutputElement.java
@@ -75,6 +75,13 @@ class OutputElement implements OutputNode {
    private Mode mode;
    
    /**
+    * The {@link IndentationMode} is used to indicate if the serializer should apply indentation
+    * when writing this node. If the mode is disabled, this node will not be indented. If the mode
+    * is enabled, the indentation set in the {@link Format} will be applied.
+    */
+   private IndentationMode indentationMode;
+   
+   /**
     * Constructor for the <code>OutputElement</code> object. This is
     * used to create an output element that can create elements for
     * an XML document. This requires the writer that is used to 
@@ -91,6 +98,7 @@ class OutputElement implements OutputNode {
       this.writer = writer;           
       this.parent = parent;
       this.name = name;
+      this.indentationMode = IndentationMode.ENABLED;
    }     
 
    /**
@@ -388,5 +396,13 @@ class OutputElement implements OutputNode {
     */
    public String toString() {
       return String.format("element %s", name);
+   }
+
+   public IndentationMode getIndentationMode() {
+      return indentationMode;
+   }
+
+   public void setIndentationMode(IndentationMode mode) {
+      this.indentationMode = mode;
    }
 }

--- a/src/main/java/org/simpleframework/xml/stream/OutputNode.java
+++ b/src/main/java/org/simpleframework/xml/stream/OutputNode.java
@@ -241,4 +241,19 @@ public interface OutputNode extends Node {
     * @return true if this node has already been committed
     */
    boolean isCommitted();
+   
+   /**
+    * The {@link IndentationMode} is used to indicate if the serializer should apply indentation
+    * when writing this node. If the mode is disabled, this node will not be indented. If the mode
+    * is enabled, the indentation set in the {@link Format} will be applied. The default is to
+    * enable indentation
+    */
+   IndentationMode getIndentationMode();
+   
+   /**
+    * The {@link IndentationMode} is used to indicate if the serializer should apply indentation
+    * when writing this node. If the mode is disabled, this node will not be indented. If the mode
+    * is enabled, the indentation set in the {@link Format} will be applied.
+    */
+   void setIndentationMode(IndentationMode mode);
 }

--- a/src/main/java/org/simpleframework/xml/stream/OutputNode.java
+++ b/src/main/java/org/simpleframework/xml/stream/OutputNode.java
@@ -201,15 +201,16 @@ public interface OutputNode extends Node {
     */
    OutputNode getParent();
    
-   /**
-    * This is used to create a child element within the element that
-    * this object represents. When a new child is created with this
-    * method then the previous child is committed to the document.
-    * The created <code>OutputNode</code> object can be used to add
-    * attributes to the child element as well as other elements.
-    *
-    * @param name this is the name of the child element to create
-    */ 
+   	/**
+	 * This is used to create a child element within the element that this object represents. When a
+	 * new child is created with this method then the previous child is committed to the document.
+	 * The created <code>OutputNode</code> object can be used to add attributes to the child element
+	 * as well as other elements.
+	 *
+	 * @param name this is the name of the child element to create. If the name is
+	 *            <code>null</code>, a text node is created, which is useful for creating elements
+	 *            with mixed content.
+	 */ 
    OutputNode getChild(String name) throws Exception;        
 
    /**

--- a/src/test/java/org/simpleframework/xml/stream/DisableIndentationTest.java
+++ b/src/test/java/org/simpleframework/xml/stream/DisableIndentationTest.java
@@ -1,0 +1,32 @@
+package org.simpleframework.xml.stream;
+
+import java.io.StringWriter;
+
+import org.simpleframework.xml.ValidationTestCase;
+
+/**
+ * Indentation can be disabled on individual nodes.
+ */
+public class DisableIndentationTest extends ValidationTestCase {
+	public static final String EXPECTED = 
+		"<root>\n"+
+		"  <a><b>B</b></a>\n" +
+		"</root>";
+
+	public void testMixedContent() throws Exception {
+		StringWriter out = new StringWriter();
+		OutputNode root = NodeBuilder.write(out, new Format(2))
+			.getChild("root");
+
+		OutputNode a = root.getChild("a");
+		a.setIndentationMode(IndentationMode.DISABLED);
+
+		OutputNode b = a.getChild("b");
+		b.setValue("B");
+		
+		root.commit();
+		validate(out.toString());
+
+		assertEquals(EXPECTED, out.toString());
+	}
+}

--- a/src/test/java/org/simpleframework/xml/stream/MixedContentSerializationTest.java
+++ b/src/test/java/org/simpleframework/xml/stream/MixedContentSerializationTest.java
@@ -1,0 +1,31 @@
+package org.simpleframework.xml.stream;
+
+import java.io.StringWriter;
+
+import org.simpleframework.xml.ValidationTestCase;
+
+public class MixedContentSerializationTest extends ValidationTestCase {
+
+	public static final String EXPECTED = "<root>First line<a>A</a>Second line</root>";
+
+	public void testMixedContent() throws Exception {
+		StringWriter out = new StringWriter();
+		OutputNode root = NodeBuilder.write(out, new Format(0))
+			.getChild("root");
+
+		OutputNode textNode1 = root.getChild(null);
+		textNode1.setValue("First line");
+
+		OutputNode a = root.getChild("a");
+		a.setValue("A");
+
+		OutputNode textNode2 = root.getChild(null);
+		textNode2.setValue("Second line");
+
+		root.commit();
+		validate(out.toString());
+
+		assertEquals(EXPECTED, out.toString());
+	}
+
+}


### PR DESCRIPTION
It is now possible to create a child element of an OutputName without a name (name is null). The NodeWriter will not write start and end tags of elements without a name.

This allows writing mixed content elements, but is currently only useful if the formatter does not indent.
